### PR TITLE
Display 'Reason' Field for each Finding

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,6 +152,11 @@
                                 <h5>Expected</h5>
                                 <code x-text="result.expected_result"></code>
                             </div>
+
+                            <div x-show="result.reason">
+                                <h5>Reason</h5>
+                                <code x-text="result.reason"></code>
+                            </div>
                             
                         </article>
                     </div>


### PR DESCRIPTION
The "reason" field contains valuable information that can help users understand why a particular finding was flagged.
Currently, the HTML GUI does not show the "reason" field.